### PR TITLE
feat: add support for --skip-crds flag

### DIFF
--- a/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
@@ -50,6 +50,7 @@ public class InstallCommand extends HelmCommand<Release> {
   private boolean disableOpenApiValidation;
   private boolean dryRun;
   private DryRun dryRunOption;
+  private boolean skipCrds;
   private boolean wait;
   private int timeout;
   private final Map<String, String> values;
@@ -94,6 +95,7 @@ public class InstallCommand extends HelmCommand<Release> {
       toInt(disableOpenApiValidation),
       toInt(dryRun),
       dryRunOption == null ? null : dryRunOption.name().toLowerCase(Locale.ROOT),
+      toInt(skipCrds),
       toInt(wait),
       timeout,
       urlEncode(values),
@@ -264,6 +266,18 @@ public class InstallCommand extends HelmCommand<Release> {
    */
   public InstallCommand withDryRunOption(DryRun dryRunOption) {
     this.dryRunOption = dryRunOption;
+    return this;
+  }
+
+  /**
+   * Skip CRDs during installation.
+   * <p>
+   * If set, no CRDs will be installed. By default, CRDs are installed if not already present.
+   *
+   * @return this {@link InstallCommand} instance.
+   */
+  public InstallCommand skipCrds() {
+    this.skipCrds = true;
     return this;
   }
 

--- a/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
@@ -36,6 +36,7 @@ public class TemplateCommand extends HelmCommand<String> {
   private String chart;
   private String namespace;
   private boolean dependencyUpdate;
+  private boolean skipCrds;
   private final Map<String, String> values;
   private final List<Path> valuesFiles;
   private Path certFile;
@@ -66,6 +67,7 @@ public class TemplateCommand extends HelmCommand<String> {
       chart,
       namespace,
       toInt(dependencyUpdate),
+      toInt(skipCrds),
       urlEncode(values),
       toString(valuesFiles),
       toString(certFile),
@@ -134,6 +136,18 @@ public class TemplateCommand extends HelmCommand<String> {
    */
   public TemplateCommand dependencyUpdate() {
     this.dependencyUpdate = true;
+    return this;
+  }
+
+  /**
+   * Skip CRDs during template rendering.
+   * <p>
+   * If set, no CRDs will be included in the rendered templates.
+   *
+   * @return this {@link TemplateCommand} instance.
+   */
+  public TemplateCommand skipCrds() {
+    this.skipCrds = true;
     return this;
   }
 

--- a/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
@@ -54,6 +54,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
   private boolean disableOpenApiValidation;
   private boolean dryRun;
   private DryRun dryRunOption;
+  private boolean skipCrds;
   private boolean wait;
   private int timeout;
   private final Map<String, String> values;
@@ -102,6 +103,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
       toInt(disableOpenApiValidation),
       toInt(dryRun),
       dryRunOption == null ? null : dryRunOption.name().toLowerCase(Locale.ROOT),
+      toInt(skipCrds),
       toInt(wait),
       timeout,
       urlEncode(values),
@@ -316,6 +318,18 @@ public class UpgradeCommand extends HelmCommand<Release> {
    */
   public UpgradeCommand withDryRunOption(DryRun dryRunOption) {
     this.dryRunOption = dryRunOption;
+    return this;
+  }
+
+  /**
+   * Skip CRDs during upgrade.
+   * <p>
+   * If set, no CRDs will be installed or upgraded. By default, CRDs are installed if not already present.
+   *
+   * @return this {@link UpgradeCommand} instance.
+   */
+  public UpgradeCommand skipCrds() {
+    this.skipCrds = true;
     return this;
   }
 

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmInstallTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmInstallTest.java
@@ -228,6 +228,19 @@ class HelmInstallTest {
         .hasFieldOrPropertyWithValue("name", "test")
         .hasFieldOrPropertyWithValue("status", "deployed");
     }
+
+    @Test
+    void skipCrds() {
+      final Release result = helm.install()
+        .clientOnly()
+        .debug()
+        .withName("test-skip-crds")
+        .skipCrds()
+        .call();
+      assertThat(result)
+        .returns("test-skip-crds", Release::getName)
+        .returns("deployed", Release::getStatus);
+    }
   }
 
   @Nested

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmKubernetesTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmKubernetesTest.java
@@ -555,6 +555,19 @@ class HelmKubernetesTest {
             "beginning wait for 3 resources with timeout of 5m30s"
           );
       }
+
+      @Test
+      void skipCrds() {
+        helm.install().withName("upgrade-skip-crds").withKubeConfig(kubeConfigFile).call();
+        final Release result = helm.upgrade()
+          .withKubeConfig(kubeConfigFile)
+          .withName("upgrade-skip-crds")
+          .skipCrds()
+          .call();
+        assertThat(result)
+          .returns("2", Release::getRevision)
+          .returns("deployed", Release::getStatus);
+      }
     }
 
     @Nested

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
@@ -107,6 +107,15 @@ class HelmTemplateTest {
         .hasMessageContaining("# Source: local-chart-test")
         .hasMessageContaining("name: release-name-local-chart-test");
     }
+
+    @Test
+    void skipCrds() {
+      final String result = helm.template()
+        .skipCrds()
+        .call();
+      assertThat(result)
+        .contains("name: release-name-local-chart-test");
+    }
   }
 
   @Nested

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/InstallOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/InstallOptions.java
@@ -39,6 +39,7 @@ import com.sun.jna.Structure;
   "disableOpenApiValidation",
   "dryRun",
   "dryRunOption",
+  "skipCRDs",
   "wait",
   "timeout",
   "values",
@@ -71,6 +72,7 @@ public class InstallOptions extends Structure {
   public int disableOpenApiValidation;
   public int dryRun;
   public String dryRunOption;
+  public int skipCRDs;
   public int wait;
   public int timeout;
   public String values;
@@ -102,6 +104,7 @@ public class InstallOptions extends Structure {
     int disableOpenApiValidation,
     int dryRun,
     String dryRunOption,
+    int skipCRDs,
     int wait,
     int timeout,
     String values,
@@ -132,6 +135,7 @@ public class InstallOptions extends Structure {
     this.disableOpenApiValidation = disableOpenApiValidation;
     this.dryRun = dryRun;
     this.dryRunOption = dryRunOption;
+    this.skipCRDs = skipCRDs;
     this.wait = wait;
     this.timeout = timeout;
     this.values = values;

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/TemplateOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/TemplateOptions.java
@@ -28,6 +28,7 @@
   "chart",
   "namespace",
   "dependencyUpdate",
+  "skipCRDs",
   "values",
   "valuesFiles",
   "certFile",
@@ -45,6 +46,7 @@ public class TemplateOptions extends Structure {
   public String chart;
   public String namespace;
   public int dependencyUpdate;
+  public int skipCRDs;
   public String values;
   public String valuesFiles;
   public String certFile;
@@ -62,6 +64,7 @@ public class TemplateOptions extends Structure {
     String chart,
     String namespace,
     int dependencyUpdate,
+    int skipCRDs,
     String values,
     String valuesFiles,
     String certFile,
@@ -78,6 +81,7 @@ public class TemplateOptions extends Structure {
     this.chart = chart;
     this.namespace = namespace;
     this.dependencyUpdate = dependencyUpdate;
+    this.skipCRDs = skipCRDs;
     this.values = values;
     this.valuesFiles = valuesFiles;
     this.certFile = certFile;

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/UpgradeOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/UpgradeOptions.java
@@ -43,6 +43,7 @@ import com.sun.jna.Structure;
   "disableOpenApiValidation",
   "dryRun",
   "dryRunOption",
+  "skipCRDs",
   "wait",
   "timeout",
   "values",
@@ -78,6 +79,7 @@ public class UpgradeOptions extends Structure {
   public int disableOpenApiValidation;
   public int dryRun;
   public String dryRunOption;
+  public int skipCRDs;
   public int wait;
   public int timeout;
   public String values;
@@ -113,6 +115,7 @@ public class UpgradeOptions extends Structure {
     int disableOpenApiValidation,
     int dryRun,
     String dryRunOption,
+    int skipCRDs,
     int wait,
     int timeout,
     String values,
@@ -147,6 +150,7 @@ public class UpgradeOptions extends Structure {
     this.disableOpenApiValidation = disableOpenApiValidation;
     this.dryRun = dryRun;
     this.dryRunOption = dryRunOption;
+    this.skipCRDs = skipCRDs;
     this.wait = wait;
     this.timeout = timeout;
     this.values = values;

--- a/native/internal/helm/install.go
+++ b/native/internal/helm/install.go
@@ -53,6 +53,7 @@ type InstallOptions struct {
 	DisableOpenApiValidation bool
 	DryRun                   bool
 	DryRunOption             string
+	SkipCRDs                 bool
 	Wait                     bool
 	Timeout                  time.Duration
 	Values                   string
@@ -130,6 +131,7 @@ func install(options *InstallOptions) (*release.Release, *installOutputs, error)
 	client.Devel = options.Devel
 	client.DryRun = options.DryRun
 	client.DryRunOption = dryRunOption(options.DryRunOption)
+	client.SkipCRDs = options.SkipCRDs
 	client.Wait = options.Wait
 	client.Timeout = options.Timeout
 	client.ClientOnly = options.ClientOnly

--- a/native/internal/helm/template.go
+++ b/native/internal/helm/template.go
@@ -29,6 +29,7 @@ type TemplateOptions struct {
 	Chart            string
 	Namespace        string
 	DependencyUpdate bool
+	SkipCRDs         bool
 	Values           string
 	ValuesFiles      string
 	Debug            bool
@@ -51,6 +52,7 @@ func Template(options *TemplateOptions) (string, error) {
 		Chart:            options.Chart,
 		Namespace:        options.Namespace,
 		DependencyUpdate: options.DependencyUpdate,
+		SkipCRDs:         options.SkipCRDs,
 		Values:           options.Values,
 		ValuesFiles:      options.ValuesFiles,
 		Debug:            options.Debug,

--- a/native/internal/helm/upgrade.go
+++ b/native/internal/helm/upgrade.go
@@ -44,6 +44,7 @@ type UpgradeOptions struct {
 	DisableOpenApiValidation bool
 	DryRun                   bool
 	DryRunOption             string
+	SkipCRDs                 bool
 	Wait                     bool
 	Timeout                  time.Duration
 	Values                   string
@@ -102,6 +103,7 @@ func Upgrade(options *UpgradeOptions) (string, error) {
 				DisableOpenApiValidation: options.DisableOpenApiValidation,
 				DryRun:                   options.DryRun,
 				DryRunOption:             options.DryRunOption,
+				SkipCRDs:                 options.SkipCRDs,
 				Wait:                     options.Wait,
 				Timeout:                  options.Timeout,
 				Values:                   options.Values,
@@ -133,6 +135,7 @@ func Upgrade(options *UpgradeOptions) (string, error) {
 	client.DisableOpenAPIValidation = options.DisableOpenApiValidation
 	client.DryRun = options.DryRun
 	client.DryRunOption = dryRunOption(options.DryRunOption)
+	client.SkipCRDs = options.SkipCRDs
 	client.Wait = options.Wait
 	client.Timeout = options.Timeout
 	client.CertFile = options.CertFile

--- a/native/main.go
+++ b/native/main.go
@@ -55,6 +55,7 @@ struct InstallOptions {
 	int   disableOpenApiValidation;
 	int   dryRun;
 	char* dryRunOption;
+	int   skipCRDs;
 	int   wait;
 	int   timeout;
 	char* values;
@@ -169,6 +170,7 @@ struct TemplateOptions {
 	char* chart;
 	char* namespace;
 	int   dependencyUpdate;
+	int   skipCRDs;
 	char* values;
 	char* valuesFiles;
 	char* certFile;
@@ -222,6 +224,7 @@ struct UpgradeOptions {
 	int   disableOpenApiValidation;
 	int   dryRun;
 	char* dryRunOption;
+	int   skipCRDs;
 	int   wait;
 	int   timeout;
 	char* values;
@@ -353,6 +356,7 @@ func Install(options *C.struct_InstallOptions) C.Result {
 			DisableOpenApiValidation: options.disableOpenApiValidation == 1,
 			DryRun:                   options.dryRun == 1,
 			DryRunOption:             C.GoString(options.dryRunOption),
+			SkipCRDs:                 options.skipCRDs == 1,
 			Wait:                     options.wait == 1,
 			Timeout:                  timeout,
 			Values:                   C.GoString(options.values),
@@ -607,6 +611,7 @@ func Template(options *C.struct_TemplateOptions) C.Result {
 			Chart:            C.GoString(options.chart),
 			Namespace:        C.GoString(options.namespace),
 			DependencyUpdate: options.dependencyUpdate == 1,
+			SkipCRDs:         options.skipCRDs == 1,
 			Values:           C.GoString(options.values),
 			ValuesFiles:      C.GoString(options.valuesFiles),
 			CertOptions: helm.CertOptions{
@@ -689,6 +694,7 @@ func Upgrade(options *C.struct_UpgradeOptions) C.Result {
 			DisableOpenApiValidation: options.disableOpenApiValidation == 1,
 			DryRun:                   options.dryRun == 1,
 			DryRunOption:             C.GoString(options.dryRunOption),
+			SkipCRDs:                 options.skipCRDs == 1,
 			Wait:                     options.wait == 1,
 			Timeout:                  timeout,
 			Values:                   C.GoString(options.values),


### PR DESCRIPTION
Closes #316

## Summary
This PR adds support for Helm's `--skip-crds` flag to the Java client, allowing users to skip Custom Resource Definition (CRD) installation during chart operations.

## Changes
- Added `skipCrds()` method to `InstallCommand`, `UpgradeCommand`, and `TemplateCommand`
- Implemented support across all layers:
  - Go native layer (InstallOptions, UpgradeOptions, TemplateOptions)
  - C bindings (FFI layer)
  - JNA bridge layer (InstallOptions.java, UpgradeOptions.java, TemplateOptions.java)
  - Java API layer (InstallCommand.java, UpgradeCommand.java, TemplateCommand.java)
- Added tests for the new functionality

## Usage Example
```java
// Install without CRDs
Helm.install("my-chart")
  .withName("my-release")
  .skipCrds()
  .call();

// Upgrade without CRDs
Helm.upgrade("my-chart")
  .withName("my-release")
  .skipCrds()
  .call();

// Template without CRDs
String manifests = Helm.template("my-chart")
  .skipCrds()
  .call();
```

## Testing
- Added tests in `HelmInstallTest`, `HelmTemplateTest`, and `HelmKubernetesTest`
- All existing tests pass
- Native libraries rebuilt with updated struct definitions