### PR TITLE
feat: add support for --set-file flag

### DIFF
--- a/helm-java/src/main/java/com/marcnuri/helm/HelmCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/HelmCommand.java
@@ -55,16 +55,16 @@ public abstract class HelmCommand<T> implements Callable<T> {
     return result;
   }
 
-  static String urlEncode(Map<String, String> values) {
+  static <T> String urlEncode(Map<String, T> entries, Function<T, String> valueMapper) {
     final StringBuilder sb = new StringBuilder();
-    for (Map.Entry<String, String> entry : values.entrySet()) {
+    for (Map.Entry<String, T> entry : entries.entrySet()) {
       if (sb.length() > 0) {
         sb.append("&");
       }
       try {
         sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name()))
           .append("=")
-          .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name()));
+          .append(URLEncoder.encode(valueMapper.apply(entry.getValue()), StandardCharsets.UTF_8.name()));
       } catch (UnsupportedEncodingException e) {
         throw new IllegalArgumentException("Invalid entry: " + entry.getKey() + "=" + entry.getValue(), e);
       }

--- a/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 
 import static com.marcnuri.helm.Release.parseSingle;
 
@@ -56,6 +57,7 @@ public class InstallCommand extends HelmCommand<Release> {
   private boolean wait;
   private int timeout;
   private final Map<String, String> values;
+  private final Map<String, Path> setFiles;
   private final List<Path> valuesFiles;
   private Path kubeConfig;
   private String kubeConfigContents;
@@ -77,6 +79,7 @@ public class InstallCommand extends HelmCommand<Release> {
     super(helmLib);
     this.chart = toString(chart);
     this.values = new LinkedHashMap<>();
+    this.setFiles = new LinkedHashMap<>();
     this.valuesFiles = new ArrayList<>();
   }
 
@@ -101,7 +104,8 @@ public class InstallCommand extends HelmCommand<Release> {
       toInt(skipCrds),
       toInt(wait),
       timeout,
-      urlEncode(values),
+      urlEncode(values, Function.identity()),
+      urlEncode(setFiles, HelmCommand::toString),
       toString(valuesFiles),
       toString(kubeConfig),
       kubeConfigContents,
@@ -332,6 +336,20 @@ public class InstallCommand extends HelmCommand<Release> {
    */
   public InstallCommand set(String key, Object value) {
     this.values.put(key, value == null ? "" : value.toString());
+    return this;
+  }
+
+  /**
+   * Set a value for the chart by reading it from a file.
+   * <p>
+   * The file contents will be used as the value for the specified key.
+   *
+   * @param key  the key.
+   * @param file the path to the file containing the value.
+   * @return this {@link InstallCommand} instance.
+   */
+  public InstallCommand setFile(String key, Path file) {
+    this.setFiles.put(key, file);
     return this;
   }
 

--- a/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @author Marc Nuri
@@ -40,6 +41,7 @@ public class TemplateCommand extends HelmCommand<String> {
   private boolean dependencyUpdate;
   private boolean skipCrds;
   private final Map<String, String> values;
+  private final Map<String, Path> setFiles;
   private final List<Path> valuesFiles;
   private Path certFile;
   private Path keyFile;
@@ -58,6 +60,7 @@ public class TemplateCommand extends HelmCommand<String> {
     super(helmLib);
     this.chart = toString(chart);
     this.values = new LinkedHashMap<>();
+    this.setFiles = new LinkedHashMap<>();
     this.valuesFiles = new ArrayList<>();
   }
 
@@ -71,7 +74,8 @@ public class TemplateCommand extends HelmCommand<String> {
       kubeVersion,
       toInt(dependencyUpdate),
       toInt(skipCrds),
-      urlEncode(values),
+      urlEncode(values, Function.identity()),
+      urlEncode(setFiles, HelmCommand::toString),
       toString(valuesFiles),
       toString(certFile),
       toString(keyFile),
@@ -179,6 +183,20 @@ public class TemplateCommand extends HelmCommand<String> {
    */
   public TemplateCommand set(String key, Object value) {
     this.values.put(key, value == null ? "" : value.toString());
+    return this;
+  }
+
+  /**
+   * Set a value for the chart by reading it from a file.
+   * <p>
+   * The file contents will be used as the value for the specified key.
+   *
+   * @param key  the key.
+   * @param file the path to the file containing the value.
+   * @return this {@link TemplateCommand} instance.
+   */
+  public TemplateCommand setFile(String key, Path file) {
+    this.setFiles.put(key, file);
     return this;
   }
 

--- a/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 
 import static com.marcnuri.helm.Release.parseSingle;
 
@@ -60,6 +61,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
   private boolean wait;
   private int timeout;
   private final Map<String, String> values;
+  private final Map<String, Path> setFiles;
   private final List<Path> valuesFiles;
   private Path kubeConfig;
   private String kubeConfigContents;
@@ -81,6 +83,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
     super(helmLib);
     this.chart = toString(chart);
     this.values = new LinkedHashMap<>();
+    this.setFiles = new LinkedHashMap<>();
     this.valuesFiles = new ArrayList<>();
   }
 
@@ -109,7 +112,8 @@ public class UpgradeCommand extends HelmCommand<Release> {
       toInt(skipCrds),
       toInt(wait),
       timeout,
-      urlEncode(values),
+      urlEncode(values, Function.identity()),
+      urlEncode(setFiles, HelmCommand::toString),
       toString(valuesFiles),
       toString(kubeConfig),
       kubeConfigContents,
@@ -384,6 +388,20 @@ public class UpgradeCommand extends HelmCommand<Release> {
    */
   public UpgradeCommand set(String key, Object value) {
     this.values.put(key, value == null ? "" : value.toString());
+    return this;
+  }
+
+  /**
+   * Set a value for the chart by reading it from a file.
+   * <p>
+   * The file contents will be used as the value for the specified key.
+   *
+   * @param key  the key.
+   * @param file the path to the file containing the value.
+   * @return this {@link UpgradeCommand} instance.
+   */
+  public UpgradeCommand setFile(String key, Path file) {
+    this.setFiles.put(key, file);
     return this;
   }
 

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmInstallTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmInstallTest.java
@@ -218,6 +218,24 @@ class HelmInstallTest {
     }
 
     @Test
+    void withSetFile() throws IOException {
+      final Path configFile = Files.write(tempDir.resolve("config.txt"),
+        "foobar".getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+      final Release result = helm.install()
+        .clientOnly()
+        .debug()
+        .withName("test")
+        .setFile("configData", configFile)
+        .call();
+      assertThat(result)
+        .extracting(Release::getOutput).asString()
+        .contains(
+          "NAME: test\n",
+          "configData: foobar"
+        );
+    }
+
+    @Test
     void withDisableOpenApiValidation() {
       final Release result = helm.install()
         .clientOnly()

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmKubernetesTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmKubernetesTest.java
@@ -646,6 +646,24 @@ class HelmKubernetesTest {
           .returns("2", Release::getRevision)
           .returns("deployed", Release::getStatus);
       }
+
+      @Test
+      void withSetFile(@TempDir Path tempDir) throws IOException {
+        final Path configFile = Files.write(tempDir.resolve("upgrade-config.txt"),
+          "foobar".getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+        helm.install().withName("upgrade-with-set-file").withKubeConfig(kubeConfigFile).call();
+        final Release result = helm.upgrade()
+          .withKubeConfig(kubeConfigFile)
+          .withName("upgrade-with-set-file")
+          .setFile("configData", configFile)
+          .debug()
+          .call();
+        assertThat(result)
+          .returns("2", Release::getRevision)
+          .returns("deployed", Release::getStatus)
+          .extracting(Release::getOutput).asString()
+          .contains("configData: foobar");
+      }
     }
 
     @Nested

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
@@ -110,6 +110,17 @@ class HelmTemplateTest {
     }
 
     @Test
+    void withSetFile() throws IOException {
+      final Path replicaFile = Files.write(tempDir.resolve("replica-count.txt"),
+        "42".getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+      final String result = helm.template()
+        .setFile("replicaCount", replicaFile)
+        .call();
+      assertThat(result)
+        .contains("replicas: 42");
+    }
+
+    @Test
     void withKubeVersion() {
       final String result = helm.template()
         .withKubeVersion("1.21.0")

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/InstallOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/InstallOptions.java
@@ -45,6 +45,7 @@ import com.sun.jna.Structure;
   "wait",
   "timeout",
   "values",
+  "setFiles",
   "valuesFiles",
   "kubeConfig",
   "kubeConfigContents",
@@ -79,6 +80,7 @@ public class InstallOptions extends Structure {
   public int wait;
   public int timeout;
   public String values;
+  public String setFiles;
   public String valuesFiles;
   public String kubeConfig;
   public String kubeConfigContents;
@@ -112,6 +114,7 @@ public class InstallOptions extends Structure {
     int wait,
     int timeout,
     String values,
+    String setFiles,
     String valuesFiles,
     String kubeConfig,
     String kubeConfigContents,
@@ -144,6 +147,7 @@ public class InstallOptions extends Structure {
     this.wait = wait;
     this.timeout = timeout;
     this.values = values;
+    this.setFiles = setFiles;
     this.valuesFiles = valuesFiles;
     this.kubeConfig = kubeConfig;
     this.kubeConfigContents = kubeConfigContents;

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/TemplateOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/TemplateOptions.java
@@ -32,6 +32,7 @@
   "dependencyUpdate",
   "skipCRDs",
   "values",
+  "setFiles",
   "valuesFiles",
   "certFile",
   "keyFile",
@@ -51,6 +52,7 @@ public class TemplateOptions extends Structure {
   public int dependencyUpdate;
   public int skipCRDs;
   public String values;
+  public String setFiles;
   public String valuesFiles;
   public String certFile;
   public String keyFile;
@@ -70,6 +72,7 @@ public class TemplateOptions extends Structure {
     int dependencyUpdate,
     int skipCRDs,
     String values,
+    String setFiles,
     String valuesFiles,
     String certFile,
     String keyFile,
@@ -88,6 +91,7 @@ public class TemplateOptions extends Structure {
     this.dependencyUpdate = dependencyUpdate;
     this.skipCRDs = skipCRDs;
     this.values = values;
+    this.setFiles = setFiles;
     this.valuesFiles = valuesFiles;
     this.certFile = certFile;
     this.keyFile = keyFile;

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/UpgradeOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/UpgradeOptions.java
@@ -49,6 +49,7 @@ import com.sun.jna.Structure;
   "wait",
   "timeout",
   "values",
+  "setFiles",
   "valuesFiles",
   "kubeConfig",
   "kubeConfigContents",
@@ -86,6 +87,7 @@ public class UpgradeOptions extends Structure {
   public int wait;
   public int timeout;
   public String values;
+  public String setFiles;
   public String valuesFiles;
   public String kubeConfig;
   public String kubeConfigContents;
@@ -123,6 +125,7 @@ public class UpgradeOptions extends Structure {
     int wait,
     int timeout,
     String values,
+    String setFiles,
     String valuesFiles,
     String kubeConfig,
     String kubeConfigContents,
@@ -159,6 +162,7 @@ public class UpgradeOptions extends Structure {
     this.wait = wait;
     this.timeout = timeout;
     this.values = values;
+    this.setFiles = setFiles;
     this.valuesFiles = valuesFiles;
     this.kubeConfig = kubeConfig;
     this.kubeConfigContents = kubeConfigContents;

--- a/native/internal/helm/install.go
+++ b/native/internal/helm/install.go
@@ -59,6 +59,7 @@ type InstallOptions struct {
 	Wait                     bool
 	Timeout                  time.Duration
 	Values                   string
+	SetFiles                 string
 	ValuesFiles              string
 	KubeConfig               string
 	KubeConfigContents       string
@@ -171,7 +172,7 @@ func install(options *InstallOptions) (*release.Release, *installOutputs, error)
 		return nil, outputs, invalidDryRun
 	}
 	// Values
-	vals, err := mergeValues(options.Values, options.ValuesFiles)
+	vals, err := mergeValues(options.Values, options.SetFiles, options.ValuesFiles)
 	if err != nil {
 		return nil, outputs, err
 	}
@@ -304,8 +305,12 @@ func parseValuesSet(values string) ([]string, error) {
 }
 
 // mergeValues returns a map[string]interface{} with the provided processed values
-func mergeValues(encodedValuesMap, encodedValuesFiles string) (map[string]interface{}, error) {
+func mergeValues(encodedValuesMap, encodedSetFiles, encodedValuesFiles string) (map[string]interface{}, error) {
 	valuesSet, err := parseValuesSet(encodedValuesMap)
+	if err != nil {
+		return nil, err
+	}
+	setFiles, err := parseValuesSet(encodedSetFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -317,6 +322,7 @@ func mergeValues(encodedValuesMap, encodedValuesFiles string) (map[string]interf
 	}
 	return (&values.Options{
 		Values:     valuesSet,
+		FileValues: setFiles,
 		ValueFiles: valueFiles,
 	}).MergeValues(make(getter.Providers, 0))
 }

--- a/native/internal/helm/template.go
+++ b/native/internal/helm/template.go
@@ -32,6 +32,7 @@ type TemplateOptions struct {
 	DependencyUpdate bool
 	SkipCRDs         bool
 	Values           string
+	SetFiles         string
 	ValuesFiles      string
 	Debug            bool
 	RepositoryConfig string
@@ -56,6 +57,7 @@ func Template(options *TemplateOptions) (string, error) {
 		DependencyUpdate: options.DependencyUpdate,
 		SkipCRDs:         options.SkipCRDs,
 		Values:           options.Values,
+		SetFiles:         options.SetFiles,
 		ValuesFiles:      options.ValuesFiles,
 		Debug:            options.Debug,
 		RepositoryConfig: options.RepositoryConfig,

--- a/native/internal/helm/upgrade.go
+++ b/native/internal/helm/upgrade.go
@@ -49,6 +49,7 @@ type UpgradeOptions struct {
 	Wait                     bool
 	Timeout                  time.Duration
 	Values                   string
+	SetFiles                 string
 	ValuesFiles              string
 	KubeConfig               string
 	KubeConfigContents       string
@@ -109,6 +110,8 @@ func Upgrade(options *UpgradeOptions) (string, error) {
 				Wait:                     options.Wait,
 				Timeout:                  options.Timeout,
 				Values:                   options.Values,
+				SetFiles:                 options.SetFiles,
+				ValuesFiles:              options.ValuesFiles,
 				KubeConfig:               options.KubeConfig,
 				CertOptions:              options.CertOptions,
 				Debug:                    options.Debug,
@@ -167,7 +170,7 @@ func Upgrade(options *UpgradeOptions) (string, error) {
 	}
 	ctx := context.Background()
 	// Values
-	vals, err := mergeValues(options.Values, options.ValuesFiles)
+	vals, err := mergeValues(options.Values, options.SetFiles, options.ValuesFiles)
 	if err != nil {
 		return "", err
 	}

--- a/native/main.go
+++ b/native/main.go
@@ -60,6 +60,7 @@ struct InstallOptions {
 	int   wait;
 	int   timeout;
 	char* values;
+	char* setFiles;
 	char* valuesFiles;
 	char* kubeConfig;
 	char* kubeConfigContents;
@@ -174,6 +175,7 @@ struct TemplateOptions {
 	int   dependencyUpdate;
 	int   skipCRDs;
 	char* values;
+	char* setFiles;
 	char* valuesFiles;
 	char* certFile;
 	char* keyFile;
@@ -231,6 +233,7 @@ struct UpgradeOptions {
 	int   wait;
 	int   timeout;
 	char* values;
+	char* setFiles;
 	char* valuesFiles;
 	char* kubeConfig;
 	char* kubeConfigContents;
@@ -364,6 +367,7 @@ func Install(options *C.struct_InstallOptions) C.Result {
 			Wait:                     options.wait == 1,
 			Timeout:                  timeout,
 			Values:                   C.GoString(options.values),
+			SetFiles:                 C.GoString(options.setFiles),
 			ValuesFiles:              C.GoString(options.valuesFiles),
 			KubeConfig:               C.GoString(options.kubeConfig),
 			KubeConfigContents:       C.GoString(options.kubeConfigContents),
@@ -618,6 +622,7 @@ func Template(options *C.struct_TemplateOptions) C.Result {
 			DependencyUpdate: options.dependencyUpdate == 1,
 			SkipCRDs:         options.skipCRDs == 1,
 			Values:           C.GoString(options.values),
+			SetFiles:         C.GoString(options.setFiles),
 			ValuesFiles:      C.GoString(options.valuesFiles),
 			CertOptions: helm.CertOptions{
 				CertFile:              C.GoString(options.certFile),
@@ -704,6 +709,7 @@ func Upgrade(options *C.struct_UpgradeOptions) C.Result {
 			Wait:                     options.wait == 1,
 			Timeout:                  timeout,
 			Values:                   C.GoString(options.values),
+			SetFiles:                 C.GoString(options.setFiles),
 			ValuesFiles:              C.GoString(options.valuesFiles),
 			KubeConfig:               C.GoString(options.kubeConfig),
 			KubeConfigContents:       C.GoString(options.kubeConfigContents),


### PR DESCRIPTION
Closes #318

## Summary
This PR adds support for Helm's `--set-file` flag to the Java client, allowing users to set chart values by reading contents from files.

## Changes
- Added `setFile(String key, Path file)` method to `InstallCommand`, `UpgradeCommand`, and `TemplateCommand`
- Implemented support across all layers:
  - Go native layer (InstallOptions, UpgradeOptions, TemplateOptions with SetFiles field)
  - C bindings (FFI layer with setFiles field)
  - JNA bridge layer (InstallOptions.java, UpgradeOptions.java, TemplateOptions.java)
  - Java API layer (InstallCommand.java, UpgradeCommand.java, TemplateCommand.java)
- Refactored URL encoding into a generic method using `Function<T, String>` mapper
- Added tests for the new functionality

## Usage Example
```java
Path configFile = Paths.get("/path/to/config.yaml");
Path scriptFile = Paths.get("/path/to/script.sh");

// Install with file values
Helm.install("my-chart")
  .withName("my-release")
  .setFile("config", configFile)
  .setFile("script", scriptFile)
  .call();

// Upgrade with file values
Helm.upgrade("my-chart")
  .withName("my-release")
  .setFile("config", configFile)
  .call();

// Template with file values
String manifests = Helm.template("my-chart")
  .setFile("config", configFile)
  .call();
```

## Testing
- Added tests in `HelmInstallTest`, `HelmTemplateTest`, and `HelmKubernetesTest`
- All existing tests pass
- Native libraries rebuilt with updated struct definitions