### PR TITLE
feat: add support for "helm get values" command

### DIFF
--- a/helm-java/src/main/java/com/marcnuri/helm/GetCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/GetCommand.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.marcnuri.helm;
+
+import com.marcnuri.helm.jni.GetValuesOptions;
+import com.marcnuri.helm.jni.HelmLib;
+
+import java.nio.file.Path;
+
+/**
+ * This command consists of multiple subcommands which can be used to get extended information about the release.
+ *
+ * @author Antonio Fernandez Alhambra
+ */
+public class GetCommand {
+
+  private final HelmLib helmLib;
+  private final String releaseName;
+
+  GetCommand(HelmLib helmLib, String releaseName) {
+    this.helmLib = helmLib;
+    this.releaseName = releaseName;
+  }
+
+  /**
+   * This command downloads the values file for a given release.
+   *
+   * @return the {@link GetValuesSubcommand} subcommand.
+   */
+  public GetValuesSubcommand values() {
+    return new GetValuesSubcommand(helmLib, releaseName);
+  }
+
+  public static final class GetValuesSubcommand extends HelmCommand<String> {
+
+    private final String releaseName;
+    private boolean allValues;
+    private int revision;
+    private String namespace;
+    private Path kubeConfig;
+    private String kubeConfigContents;
+
+    private GetValuesSubcommand(HelmLib helmLib, String releaseName) {
+      super(helmLib);
+      this.releaseName = releaseName;
+    }
+
+    /**
+     * Execute the get values subcommand.
+     *
+     * @return a {@link String} containing the values in YAML format.
+     */
+    @Override
+    public String call() {
+      return run(hl -> hl.GetValues(new GetValuesOptions(
+        releaseName,
+        toInt(allValues),
+        revision,
+        namespace,
+        toString(kubeConfig),
+        kubeConfigContents
+      ))).out;
+    }
+
+    /**
+     * Dump all (computed) values.
+     * <p>
+     * When set, all computed values are returned, including the default values from the chart.
+     *
+     * @return this {@link GetValuesSubcommand} instance.
+     */
+    public GetValuesSubcommand allValues() {
+      this.allValues = true;
+      return this;
+    }
+
+    /**
+     * Get the named release with revision.
+     * <p>
+     * If not specified, the latest release is returned.
+     *
+     * @param revision the revision number.
+     * @return this {@link GetValuesSubcommand} instance.
+     */
+    public GetValuesSubcommand withRevision(int revision) {
+      this.revision = revision;
+      return this;
+    }
+
+    /**
+     * Kubernetes namespace scope for this request.
+     *
+     * @param namespace the Kubernetes namespace for this request.
+     * @return this {@link GetValuesSubcommand} instance.
+     */
+    public GetValuesSubcommand withNamespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    /**
+     * Set the path ./kube/config file to use.
+     *
+     * @param kubeConfig the path to kube config file.
+     * @return this {@link GetValuesSubcommand} instance.
+     */
+    public GetValuesSubcommand withKubeConfig(Path kubeConfig) {
+      this.kubeConfig = kubeConfig;
+      return this;
+    }
+
+    /**
+     * Set the kube config to use.
+     *
+     * @param kubeConfigContents the contents of the kube config file.
+     * @return this {@link GetValuesSubcommand} instance.
+     */
+    public GetValuesSubcommand withKubeConfigContents(String kubeConfigContents) {
+      this.kubeConfigContents = kubeConfigContents;
+      return this;
+    }
+  }
+}

--- a/helm-java/src/main/java/com/marcnuri/helm/Helm.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/Helm.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 /**
  * @author Marc Nuri
  * @author Andres F. Vallecilla
+ * @author Antonio Fernandez Alhambra
  */
 public class Helm {
 
@@ -94,6 +95,16 @@ public class Helm {
    */
   public static ListCommand list() {
     return new ListCommand(HelmLibHolder.INSTANCE);
+  }
+
+  /**
+   * This command consists of multiple subcommands which can be used to get extended information about the release.
+   *
+   * @param releaseName the name of the release.
+   * @return the {@link GetCommand} command.
+   */
+  public static GetCommand get(String releaseName) {
+    return new GetCommand(HelmLibHolder.INSTANCE, releaseName);
   }
 
   /**

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/GetValuesOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/GetValuesOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.marcnuri.helm.jni;
+
+import com.sun.jna.Structure;
+
+/**
+ * @author Antonio Fernandez Alhambra
+ */
+@Structure.FieldOrder({
+  "releaseName",
+  "allValues",
+  "revision",
+  "namespace",
+  "kubeConfig",
+  "kubeConfigContents"
+})
+public class GetValuesOptions extends Structure {
+  public String releaseName;
+  public int allValues;
+  public int revision;
+  public String namespace;
+  public String kubeConfig;
+  public String kubeConfigContents;
+
+  public GetValuesOptions(String releaseName, int allValues, int revision, String namespace, String kubeConfig, String kubeConfigContents) {
+    this.releaseName = releaseName;
+    this.allValues = allValues;
+    this.revision = revision;
+    this.namespace = namespace;
+    this.kubeConfig = kubeConfig;
+    this.kubeConfigContents = kubeConfigContents;
+  }
+}

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/HelmLib.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/HelmLib.java
@@ -21,6 +21,7 @@ import com.sun.jna.Library;
 /**
  * @author Marc Nuri
  * @author Andres F. Vallecilla
+ * @author Antonio Fernandez Alhambra
  */
 public interface HelmLib extends Library {
 
@@ -37,6 +38,8 @@ public interface HelmLib extends Library {
   Result Lint(LintOptions options);
 
   Result List(ListOptions options);
+
+  Result GetValues(GetValuesOptions options);
 
   Result Package(PackageOptions options);
 

--- a/native/internal/helm/get.go
+++ b/native/internal/helm/get.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Marc Nuri
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helm
+
+import (
+	"encoding/json"
+
+	"helm.sh/helm/v3/pkg/action"
+	"sigs.k8s.io/yaml"
+)
+
+type GetValuesOptions struct {
+	ReleaseName        string
+	AllValues          bool
+	Revision           int
+	Namespace          string
+	KubeConfig         string
+	KubeConfigContents string
+}
+
+func GetValues(options *GetValuesOptions) (string, error) {
+	cfg, err := NewCfg(&CfgOptions{
+		KubeConfig:         options.KubeConfig,
+		KubeConfigContents: options.KubeConfigContents,
+		Namespace:          options.Namespace,
+	})
+	if err != nil {
+		return "", err
+	}
+	client := action.NewGetValues(cfg)
+	client.AllValues = options.AllValues
+	if options.Revision > 0 {
+		client.Version = options.Revision
+	}
+
+	values, err := client.Run(options.ReleaseName)
+	if err != nil {
+		return "", err
+	}
+
+	// Convert values to YAML format (default Helm output format)
+	jsonBytes, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlBytes), nil
+}

--- a/native/main.go
+++ b/native/main.go
@@ -194,6 +194,15 @@ struct TestOptions {
 	int   debug;
 };
 
+struct GetValuesOptions {
+	char* releaseName;
+	int   allValues;
+	int   revision;
+	char* namespace;
+	char* kubeConfig;
+	char* kubeConfigContents;
+};
+
 struct UninstallOptions {
 	char* releaseName;
 	int   dryRun;
@@ -408,6 +417,20 @@ func List(options *C.struct_ListOptions) C.Result {
 			Superseded:         options.superseded == 1,
 			Uninstalled:        options.uninstalled == 1,
 			Uninstalling:       options.uninstalling == 1,
+			Namespace:          C.GoString(options.namespace),
+			KubeConfig:         C.GoString(options.kubeConfig),
+			KubeConfigContents: C.GoString(options.kubeConfigContents),
+		})
+	})
+}
+
+//export GetValues
+func GetValues(options *C.struct_GetValuesOptions) C.Result {
+	return runCommand(func() (string, error) {
+		return helm.GetValues(&helm.GetValuesOptions{
+			ReleaseName:        C.GoString(options.releaseName),
+			AllValues:          options.allValues == 1,
+			Revision:           int(options.revision),
 			Namespace:          C.GoString(options.namespace),
 			KubeConfig:         C.GoString(options.kubeConfig),
 			KubeConfigContents: C.GoString(options.kubeConfigContents),


### PR DESCRIPTION
Closes https://github.com/manusa/helm-java/issues/322

## Summary
- Adds support for the `helm get values` command
- Implements the full stack: Go native layer, JNA bridge, and Java command API

## Test plan
- [x] Go tests pass (`go test ./...` in native/)
- [x] Java compilation passes (`mvn clean install -Dquickly`)

## Usage

```java
// Get user-supplied values for a release
String values = Helm.get("my-release")
    .values()
    .withKubeConfig(kubeConfigPath)
    .call();

// Get all values (including chart defaults)
String allValues = Helm.get("my-release")
    .values()
    .allValues()
    .withKubeConfig(kubeConfigPath)
    .call();

// Get values for a specific revision
String revisionValues = Helm.get("my-release")
    .values()
    .withRevision(2)
    .withKubeConfig(kubeConfigPath)
    .call();
```