### PR TITLE
refactor: improve --set-file implementation and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ Release result = installCommand
   .withDryRunOption(DryRun.CLIENT)
   // Optionally wait until all Pods are in a ready state, PVCs are bound, Deployments have
   // minimum (Desired minus maxUnavailable) Pods in ready state and Services have an IP
-  // address (and Ingress if a LoadBalancer) before marking the release as successful. 
+  // address (and Ingress if a LoadBalancer) before marking the release as successful.
   .waitReady()
   // Optionally specify the time (in seconds) to wait for any individual Kubernetes operation (like Jobs for hooks) (default 300)
   .withTimeout(int timeout)
   // Optionally set typed values for the chart (can be repeated)
   .set("key", "value")
+  // Optionally set a chart value from a file's contents (equivalent to --set-file)
+  .setFile("key", Paths.get("path", "to", "file"))
   // Optionally add a values (YAML) file to source values for the chart (can specify multiple)
   .withValuesFile(Paths.get("path", "to", "valuesFile"))
   // Optionally specify the path to the kubeconfig file to use for CLI requests
@@ -602,6 +604,8 @@ String result = templateCommand
   .dependencyUpdate()
   // Optionally set values for the chart
   .set("key", "value")
+  // Optionally set a chart value from a file's contents (equivalent to --set-file)
+  .setFile("key", Paths.get("path", "to", "file"))
   // Optionally add a values (YAML) file to source values for the chart (can specify multiple)
   .withValuesFile(Paths.get("path", "to", "valuesFile"))
   // Optionally specify an SSL certificate file to identify the registry client
@@ -729,12 +733,14 @@ Release result = upgradeCommand
   .withDryRunOption(DryRun.CLIENT)
   // Optionally wait until all Pods are in a ready state, PVCs are bound, Deployments have
   // minimum (Desired minus maxUnavailable) Pods in ready state and Services have an IP
-  // address (and Ingress if a LoadBalancer) before marking the release as successful. 
+  // address (and Ingress if a LoadBalancer) before marking the release as successful.
   .waitReady()
   // Optionally specify the time (in seconds) to wait for any individual Kubernetes operation (like Jobs for hooks) (default 300)
   .withTimeout(int timeout)
   // Optionally set typed values for the chart (can be repeated)
   .set("key", "value")
+  // Optionally set a chart value from a file's contents (equivalent to --set-file)
+  .setFile("key", Paths.get("path", "to", "file"))
   // Optionally add a values (YAML) file to source values for the chart (can specify multiple)
   .withValuesFile(Paths.get("path", "to", "valuesFile"))
   // Optionally specify the path to the kubeconfig file to use for CLI requests

--- a/helm-java/src/main/java/com/marcnuri/helm/HelmCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/HelmCommand.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -55,16 +56,16 @@ public abstract class HelmCommand<T> implements Callable<T> {
     return result;
   }
 
-  static <T> String urlEncode(Map<String, T> entries, Function<T, String> valueMapper) {
+  static String urlEncode(Map<String, String> values) {
     final StringBuilder sb = new StringBuilder();
-    for (Map.Entry<String, T> entry : entries.entrySet()) {
+    for (Map.Entry<String, String> entry : values.entrySet()) {
       if (sb.length() > 0) {
         sb.append("&");
       }
       try {
         sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name()))
           .append("=")
-          .append(URLEncoder.encode(valueMapper.apply(entry.getValue()), StandardCharsets.UTF_8.name()));
+          .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name()));
       } catch (UnsupportedEncodingException e) {
         throw new IllegalArgumentException("Invalid entry: " + entry.getKey() + "=" + entry.getValue(), e);
       }
@@ -112,5 +113,13 @@ public abstract class HelmCommand<T> implements Callable<T> {
 
   static int toInt(boolean value) {
     return value ? 1 : 0;
+  }
+
+  static Map<String, String> toStringValues(Map<String, Path> paths) {
+    final Map<String, String> result = new LinkedHashMap<>();
+    for (Map.Entry<String, Path> entry : paths.entrySet()) {
+      result.put(entry.getKey(), toString(entry.getValue()));
+    }
+    return result;
   }
 }

--- a/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 
 import static com.marcnuri.helm.Release.parseSingle;
 
@@ -57,7 +56,7 @@ public class InstallCommand extends HelmCommand<Release> {
   private boolean wait;
   private int timeout;
   private final Map<String, String> values;
-  private final Map<String, Path> setFiles;
+  private final Map<String, Path> fileValues;
   private final List<Path> valuesFiles;
   private Path kubeConfig;
   private String kubeConfigContents;
@@ -79,7 +78,7 @@ public class InstallCommand extends HelmCommand<Release> {
     super(helmLib);
     this.chart = toString(chart);
     this.values = new LinkedHashMap<>();
-    this.setFiles = new LinkedHashMap<>();
+    this.fileValues = new LinkedHashMap<>();
     this.valuesFiles = new ArrayList<>();
   }
 
@@ -104,8 +103,8 @@ public class InstallCommand extends HelmCommand<Release> {
       toInt(skipCrds),
       toInt(wait),
       timeout,
-      urlEncode(values, Function.identity()),
-      urlEncode(setFiles, HelmCommand::toString),
+      urlEncode(values),
+      urlEncode(toStringValues(fileValues)),
       toString(valuesFiles),
       toString(kubeConfig),
       kubeConfigContents,
@@ -340,16 +339,17 @@ public class InstallCommand extends HelmCommand<Release> {
   }
 
   /**
-   * Set a value for the chart by reading it from a file.
+   * Set a chart value by reading it from a file (equivalent to {@code --set-file}).
    * <p>
-   * The file contents will be used as the value for the specified key.
+   * The contents of the specified file will be used as the value for the given key,
+   * overriding any default in the chart's values.yaml.
    *
-   * @param key  the key.
-   * @param file the path to the file containing the value.
+   * @param key  the value key.
+   * @param file the path to the file to read.
    * @return this {@link InstallCommand} instance.
    */
   public InstallCommand setFile(String key, Path file) {
-    this.setFiles.put(key, file);
+    this.fileValues.put(key, file);
     return this;
   }
 

--- a/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * @author Marc Nuri
@@ -41,7 +40,7 @@ public class TemplateCommand extends HelmCommand<String> {
   private boolean dependencyUpdate;
   private boolean skipCrds;
   private final Map<String, String> values;
-  private final Map<String, Path> setFiles;
+  private final Map<String, Path> fileValues;
   private final List<Path> valuesFiles;
   private Path certFile;
   private Path keyFile;
@@ -60,7 +59,7 @@ public class TemplateCommand extends HelmCommand<String> {
     super(helmLib);
     this.chart = toString(chart);
     this.values = new LinkedHashMap<>();
-    this.setFiles = new LinkedHashMap<>();
+    this.fileValues = new LinkedHashMap<>();
     this.valuesFiles = new ArrayList<>();
   }
 
@@ -74,8 +73,8 @@ public class TemplateCommand extends HelmCommand<String> {
       kubeVersion,
       toInt(dependencyUpdate),
       toInt(skipCrds),
-      urlEncode(values, Function.identity()),
-      urlEncode(setFiles, HelmCommand::toString),
+      urlEncode(values),
+      urlEncode(toStringValues(fileValues)),
       toString(valuesFiles),
       toString(certFile),
       toString(keyFile),
@@ -187,16 +186,17 @@ public class TemplateCommand extends HelmCommand<String> {
   }
 
   /**
-   * Set a value for the chart by reading it from a file.
+   * Set a chart value by reading it from a file (equivalent to {@code --set-file}).
    * <p>
-   * The file contents will be used as the value for the specified key.
+   * The contents of the specified file will be used as the value for the given key,
+   * overriding any default in the chart's values.yaml.
    *
-   * @param key  the key.
-   * @param file the path to the file containing the value.
+   * @param key  the value key.
+   * @param file the path to the file to read.
    * @return this {@link TemplateCommand} instance.
    */
   public TemplateCommand setFile(String key, Path file) {
-    this.setFiles.put(key, file);
+    this.fileValues.put(key, file);
     return this;
   }
 

--- a/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 
 import static com.marcnuri.helm.Release.parseSingle;
 
@@ -61,7 +60,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
   private boolean wait;
   private int timeout;
   private final Map<String, String> values;
-  private final Map<String, Path> setFiles;
+  private final Map<String, Path> fileValues;
   private final List<Path> valuesFiles;
   private Path kubeConfig;
   private String kubeConfigContents;
@@ -83,7 +82,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
     super(helmLib);
     this.chart = toString(chart);
     this.values = new LinkedHashMap<>();
-    this.setFiles = new LinkedHashMap<>();
+    this.fileValues = new LinkedHashMap<>();
     this.valuesFiles = new ArrayList<>();
   }
 
@@ -112,8 +111,8 @@ public class UpgradeCommand extends HelmCommand<Release> {
       toInt(skipCrds),
       toInt(wait),
       timeout,
-      urlEncode(values, Function.identity()),
-      urlEncode(setFiles, HelmCommand::toString),
+      urlEncode(values),
+      urlEncode(toStringValues(fileValues)),
       toString(valuesFiles),
       toString(kubeConfig),
       kubeConfigContents,
@@ -392,16 +391,17 @@ public class UpgradeCommand extends HelmCommand<Release> {
   }
 
   /**
-   * Set a value for the chart by reading it from a file.
+   * Set a chart value by reading it from a file (equivalent to {@code --set-file}).
    * <p>
-   * The file contents will be used as the value for the specified key.
+   * The contents of the specified file will be used as the value for the given key,
+   * overriding any default in the chart's values.yaml.
    *
-   * @param key  the key.
-   * @param file the path to the file containing the value.
+   * @param key  the value key.
+   * @param file the path to the file to read.
    * @return this {@link UpgradeCommand} instance.
    */
   public UpgradeCommand setFile(String key, Path file) {
-    this.setFiles.put(key, file);
+    this.fileValues.put(key, file);
     return this;
   }
 

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmInstallTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmInstallTest.java
@@ -346,6 +346,18 @@ class HelmInstallTest {
         );
     }
 
+    @Test
+    void withSetFileNonExistent() {
+      final Path nonExistentFile = tempDir.resolve("non-existent-file.txt");
+      final InstallCommand install = helm.install()
+        .clientOnly()
+        .withName("test-set-file-non-existent")
+        .setFile("config", nonExistentFile);
+      assertThatThrownBy(install::call)
+        .isInstanceOf(IllegalStateException.class)
+        .message().contains("non-existent-file.txt");
+    }
+
 //    @Test
 //    void withDevelopmentVersionInChart() throws IOException {
 //      final Path chartYaml = tempDir.resolve("test").resolve("Chart.yaml");

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
@@ -121,6 +121,16 @@ class HelmTemplateTest {
     }
 
     @Test
+    void withSetFileNonExistent() {
+      final Path nonExistentFile = tempDir.resolve("non-existent-file.txt");
+      final TemplateCommand templateCommand = helm.template()
+        .setFile("config", nonExistentFile);
+      assertThatThrownBy(templateCommand::call)
+        .isInstanceOf(IllegalStateException.class)
+        .message().contains("non-existent-file.txt");
+    }
+
+    @Test
     void withKubeVersion() {
       final String result = helm.template()
         .withKubeVersion("1.21.0")


### PR DESCRIPTION
Follow-up to #319 addressing code review feedback:
- Revert urlEncode to original non-generic signature
- Add toStringValues helper for Map<String, Path> conversion
- Rename setFiles to fileValues to match Helm SDK naming
- Improve setFile JavaDoc to reference --set-file flag
- Add negative test cases for non-existent file paths
- Document setFile in README for install, template, and upgrade

Refs #318 