### PR TITLE
refactor: improve helm get values and fix withKubeConfig javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ new Helm(Paths.get("path", "to", "chart")).dependency().update()
   .call();
 ```
 
+### Get
+
+Equivalent of [`helm get`](https://helm.sh/docs/helm/helm_get/).
+
+This command consists of multiple subcommands which can be used to get extended information about the release, including:
+
+#### Get values
+
+Equivalent of [`helm get values`](https://helm.sh/docs/helm/helm_get_values/).
+
+Downloads a values file for a given release.
+
+``` java
+String values = Helm.get("release-name").values()
+  // Optionally dump all (computed) values, including those from the chart's default values
+  .allValues()
+  // Optionally get the named release with a specific revision
+  .withRevision(1)
+  // Optionally specify the Kubernetes namespace
+  .withNamespace("namespace")
+  // Optionally specify the path to the kubeconfig file to use for CLI requests
+  .withKubeConfig(Paths.get("path", "to", "kubeconfig"))
+  // Optionally set the contents of the kubeconfig file as a string (takes precedence over the path)
+  .withKubeConfigContents("apiVersion: v1\nkind: Config\nclusters:\n...")
+  .call();
+```
+
 ### Install
 
 Equivalent of [`helm install`](https://helm.sh/docs/helm/helm_install/).

--- a/helm-java/src/main/java/com/marcnuri/helm/GetCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/GetCommand.java
@@ -113,7 +113,7 @@ public class GetCommand {
     }
 
     /**
-     * Set the path ./kube/config file to use.
+     * Set the path to the ~/.kube/config file to use.
      *
      * @param kubeConfig the path to kube config file.
      * @return this {@link GetValuesSubcommand} instance.

--- a/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/InstallCommand.java
@@ -365,7 +365,7 @@ public class InstallCommand extends HelmCommand<Release> {
   }
 
   /**
-   * Set the path ./kube/config file to use.
+   * Set the path to the ~/.kube/config file to use.
    *
    * @param kubeConfig the path to kube config file.
    * @return this {@link InstallCommand} instance.

--- a/helm-java/src/main/java/com/marcnuri/helm/ListCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/ListCommand.java
@@ -155,7 +155,7 @@ public class ListCommand extends HelmCommand<List<Release>> {
   }
 
   /**
-   * Set the path ./kube/config file to use.
+   * Set the path to the ~/.kube/config file to use.
    *
    * @param kubeConfig the path to kube config file.
    * @return this {@link ListCommand} instance.

--- a/helm-java/src/main/java/com/marcnuri/helm/TestCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/TestCommand.java
@@ -76,7 +76,7 @@ public class TestCommand extends HelmCommand<Release> {
   }
 
   /**
-   * Set the path ./kube/config file to use.
+   * Set the path to the ~/.kube/config file to use.
    *
    * @param kubeConfig the path to kube config file.
    * @return this {@link TestCommand} instance.

--- a/helm-java/src/main/java/com/marcnuri/helm/UninstallCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/UninstallCommand.java
@@ -128,7 +128,7 @@ public class UninstallCommand extends HelmCommand<String> {
   }
 
   /**
-   * Set the path ./kube/config file to use.
+   * Set the path to the ~/.kube/config file to use.
    *
    * @param kubeConfig the path to kube config file.
    * @return this {@link UninstallCommand} instance.

--- a/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/UpgradeCommand.java
@@ -417,7 +417,7 @@ public class UpgradeCommand extends HelmCommand<Release> {
   }
 
   /**
-   * Set the path ./kube/config file to use.
+   * Set the path to the ~/.kube/config file to use.
    *
    * @param kubeConfig the path to kube config file.
    * @return this {@link UpgradeCommand} instance.

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmKubernetesTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmKubernetesTest.java
@@ -850,6 +850,20 @@ class HelmKubernetesTest {
           .call();
         assertThat(result).isNotNull();
       }
+
+      @Test
+      void withKubeConfigContents() {
+        helm.install()
+          .withKubeConfigContents(kubeConfigContents)
+          .withName("get-values-kube-config-contents")
+          .set("replicaCount", "4")
+          .call();
+        final String result = Helm.get("get-values-kube-config-contents").values()
+          .withKubeConfigContents(kubeConfigContents)
+          .call();
+        assertThat(result)
+          .contains("replicaCount: 4");
+      }
     }
 
     @Nested

--- a/native/internal/helm/get.go
+++ b/native/internal/helm/get.go
@@ -17,8 +17,6 @@
 package helm
 
 import (
-	"encoding/json"
-
 	"helm.sh/helm/v3/pkg/action"
 	"sigs.k8s.io/yaml"
 )
@@ -53,11 +51,7 @@ func GetValues(options *GetValuesOptions) (string, error) {
 	}
 
 	// Convert values to YAML format (default Helm output format)
-	jsonBytes, err := json.Marshal(values)
-	if err != nil {
-		return "", err
-	}
-	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	yamlBytes, err := yaml.Marshal(values)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Simplify YAML serialization using yaml.Marshal directly
- Add comprehensive Go tests for GetValues (envtest)
- Add Java test for withKubeConfigContents
- Add README documentation for helm get values command
- Fix withKubeConfig javadoc typo across all commands (./kube/config → ~/.kube/config)

Follows up on #345 
Refs #322 