### PR TITLE
chore(deps): bump Go to 1.25.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.25.7
+  GO_VERSION: 1.25.10
 
 jobs:
   build-all:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.25.7
+  GO_VERSION: 1.25.10
 
 jobs:
   release:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 2 * * *' # Every day at 2am
 
 env:
-  GO_VERSION: 1.25.7
+  GO_VERSION: 1.25.10
 
 jobs:
   snapshots:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ A Java client library for Helm with no external CLI dependency. The Helm Go SDK 
 
 - Helm SDK version: tracked by `native/go.mod` (currently `helm.sh/helm/v3 v3.21.0`).
 - Java baseline: source/target 1.8. Tests run on 8 (Linux CI) or 11 (macOS/Windows CI, because macos-latest dropped 8).
-- Go baseline: pinned in `native/go.mod` and `.github/workflows/build.yml` (`GO_VERSION`); currently `1.25.7`.
+- Go baseline: pinned in `native/go.mod` and `.github/workflows/build.yml` (`GO_VERSION`); currently `1.25.10`.
 
 ## Repository layout
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-native: ## Build the native shared library for the current platform
 .PHONY: build-native-cross-platform
 build-native-cross-platform: ## Build native shared libraries for all 5 supported platforms (requires Docker)
 	go install src.techknowlogick.com/xgo@latest
-	xgo -image ghcr.io/techknowlogick/xgo:go-1.25.7 $(COMMON_BUILD_ARGS) -out native/out/helm --targets */arm64,*/amd64 ./native
+	xgo -image ghcr.io/techknowlogick/xgo:go-1.25.10 $(COMMON_BUILD_ARGS) -out native/out/helm --targets */arm64,*/amd64 ./native
 
 .PHONY: build-java
 build-java: ## Build and verify the Java artifacts (mvn clean verify)

--- a/native/go.mod
+++ b/native/go.mod
@@ -1,6 +1,6 @@
 module github.com/manusa/helm-java/native
 
-go 1.25.7
+go 1.25.10
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.25.7 to 1.25.10 (latest 1.25 patch).

- `native/go.mod`: `go 1.25.10`
- `.github/workflows/{build,release,snapshots}.yml`: `GO_VERSION: 1.25.10`
- `Makefile`: xgo image bumped to `ghcr.io/techknowlogick/xgo:go-1.25.10`
- `AGENTS.md`: updated Go baseline reference

`go mod tidy` introduces no other changes.

Supersedes #391 (closed because a branch-rename API call delete-then-recreated the head ref after a force-push, which GitHub interprets as PR closure).

## Why not Go 1.26.x?

Initial attempt bumped to `1.26.3` (current latest stable) but `make build-all` and the native Windows build both fail at the link step:

\`\`\`
ld: export_file.def:1: syntax error
ld: export_file.def: file format not recognized; treating as linker script
\`\`\`

This is [golang/go#78238](https://github.com/golang/go/issues/78238) — a regression in Go 1.26's `cmd/link/internal/ld/pe.go`. `peCreateExportFile` emits a `LIBRARY` directive into the auto-generated `.def` file using `filepath.Base(outopt)` verbatim. When the basename contains multiple dots and hyphens (e.g. `helm-windows-4.0-amd64.dll`, which is xgo's hardcoded naming convention), GNU `ld`'s DEF parser rejects it.

Verified workarounds and their problems:

- `-extldflags '-Wl,--export-all-symbols'` bypasses `peCreateExportFile` but blows past the PE 16-bit export ordinal cap (Helm's transitive symbol table is ~107k symbols).
- xgo's `-out` flag only sets the basename prefix; the `-windows-$PLATFORM-$XGOARCH.dll` suffix is hardcoded in its container's `build.sh`.
- A native cross-build (mingw-w64 on Linux) with `-o helm.dll` (no hyphens, single dot) builds cleanly under Go 1.26.3 and produces a correct PE export table — confirmed locally.

The cleanest path to 1.26.x is to remove xgo entirely and use native cross-compilers, which is now part of #393. Once that lands, the 1.26.x bump can be retried.

Upstream fix milestone: Go 1.27. No backport to 1.26.x announced.

## Test plan

- [x] `go mod tidy` clean (only the `go` directive moves)
- [x] `make test-go` passes locally under 1.25.10 (two pre-existing envtest flakes unchanged)
- [x] CI cross-platform build (`make build-all`) on Linux, native build on Windows/macOS