### PR TITLE
ci: set setup-go cache dependency path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: native/go.sum
       - name: Setup Java 8
         uses: actions/setup-java@v5
         with:
@@ -46,6 +47,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: native/go.sum
       - name: Setup Java 11
         # macos-latest does not support Java 8
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: native/go.sum
       - name: Setup Java 8
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: native/go.sum
       - name: Setup Java 8
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Summary

Adds `cache-dependency-path: native/go.sum` to each `actions/setup-go@v6` step in the build, release, and snapshots workflows.

The Go module for the native bridge lives under `native/`, so setup-go's default dependency-file discovery misses it from the repository root. Pointing the cache key at `native/go.sum` lets the existing setup-go cache use the correct dependency file without changing the build or release commands.

## Verification

- `ruby /tmp/check_workflow_yaml.rb .github/workflows/build.yml .github/workflows/release.yml .github/workflows/snapshots.yml`
- `git diff --check`

Closes #395
