### PR TITLE
fix(template): include hooks on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,8 @@ String result = templateCommand
   .withKubeVersion("v1.21.0")
   // Optionally update dependencies if they are missing before installing the chart
   .dependencyUpdate()
+  // Optionally include rendered Helm hooks in the output
+  .includeHooks()
   // Optionally set values for the chart
   .set("key", "value")
   // Optionally set a chart value from a file's contents (equivalent to --set-file)

--- a/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
+++ b/helm-java/src/main/java/com/marcnuri/helm/TemplateCommand.java
@@ -50,6 +50,7 @@ public class TemplateCommand extends HelmCommand<String> {
   private Path keyring;
   private boolean debug;
   private Path repositoryConfig;
+  private boolean includeHooks;
 
   public TemplateCommand(HelmLib helmLib) {
     this(helmLib, null);
@@ -83,7 +84,8 @@ public class TemplateCommand extends HelmCommand<String> {
       toInt(plainHttp),
       toString(keyring),
       toInt(debug),
-      toString(repositoryConfig)
+      toString(repositoryConfig),
+      toInt(includeHooks)
     ))).out;
   }
 
@@ -170,6 +172,16 @@ public class TemplateCommand extends HelmCommand<String> {
    */
   public TemplateCommand skipCrds() {
     this.skipCrds = true;
+    return this;
+  }
+
+  /**
+   * Include rendered Helm hooks in the output.
+   *
+   * @return this {@link TemplateCommand} instance.
+   */
+  public TemplateCommand includeHooks() {
+    this.includeHooks = true;
     return this;
   }
 

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmTemplateTest.java
@@ -46,15 +46,36 @@ class HelmTemplateTest {
     private Helm helm;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
       helm = Helm.create().withName("local-chart-test").withDir(tempDir).call();
+      Files.write(tempDir.resolve("local-chart-test").resolve("templates").resolve("hook.yaml"),
+        ("apiVersion: v1\n" +
+          "kind: ConfigMap\n" +
+          "metadata:\n" +
+          "  name: template-hook\n" +
+          "  annotations:\n" +
+          "    \"helm.sh/hook\": pre-install\n" +
+          "data:\n" +
+          "  marker: hook-manifest\n").getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE);
     }
 
     @Test
     void withDefaults() {
       final String result = helm.template().call();
       assertThat(result)
-        .contains("name: release-name-local-chart-test");
+        .contains("name: release-name-local-chart-test")
+        .doesNotContain("marker: hook-manifest");
+    }
+
+    @Test
+    void includeHooks() {
+      final String result = helm.template().includeHooks().call();
+      assertThat(result)
+        .contains("name: release-name-local-chart-test")
+        .contains("# Source: local-chart-test/templates/deployment.yaml\n")
+        .contains("---\n# Source: local-chart-test/templates/hook.yaml\napiVersion: v1\nkind: ConfigMap\n")
+        .contains("marker: hook-manifest");
     }
 
     @Test

--- a/lib/api/src/main/java/com/marcnuri/helm/jni/TemplateOptions.java
+++ b/lib/api/src/main/java/com/marcnuri/helm/jni/TemplateOptions.java
@@ -41,7 +41,8 @@
   "plainHttp",
   "keyring",
   "debug",
-  "repositoryConfig"
+  "repositoryConfig",
+  "includeHooks"
 })
 public class TemplateOptions extends Structure {
   public String name;
@@ -62,6 +63,7 @@ public class TemplateOptions extends Structure {
   public String keyring;
   public int debug;
   public String repositoryConfig;
+  public int includeHooks;
 
   public TemplateOptions(
     String name,
@@ -81,7 +83,8 @@ public class TemplateOptions extends Structure {
     int plainHttp,
     String keyring,
     int debug,
-    String repositoryConfig
+    String repositoryConfig,
+    int includeHooks
   ) {
     this.name = name;
     this.version = version;
@@ -101,5 +104,6 @@ public class TemplateOptions extends Structure {
     this.keyring = keyring;
     this.debug = debug;
     this.repositoryConfig = repositoryConfig;
+    this.includeHooks = includeHooks;
   }
 }

--- a/native/internal/helm/template.go
+++ b/native/internal/helm/template.go
@@ -31,6 +31,7 @@ type TemplateOptions struct {
 	KubeVersion      string
 	DependencyUpdate bool
 	SkipCRDs         bool
+	IncludeHooks     bool
 	Values           string
 	SetFiles         string
 	ValuesFiles      string
@@ -73,6 +74,19 @@ func Template(options *TemplateOptions) (string, error) {
 	var manifests bytes.Buffer
 	if _, fmtErr := fmt.Fprintln(&manifests, strings.TrimSpace(rel.Manifest)); fmtErr != nil {
 		return "", fmtErr
+	}
+	if options.IncludeHooks {
+		for _, hook := range rel.Hooks {
+			manifest := strings.TrimSpace(hook.Manifest)
+			if manifest == "" {
+				continue
+			}
+			if _, fmtErr := fmt.Fprintf(
+				&manifests, "---\n# Source: %s\n%s\n", strings.TrimSpace(hook.Path), manifest,
+			); fmtErr != nil {
+				return "", fmtErr
+			}
+		}
 	}
 	return appendToOutOrErr(&manifests, "", err)
 }

--- a/native/internal/helm/template_test.go
+++ b/native/internal/helm/template_test.go
@@ -19,6 +19,7 @@ package helm
 import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,18 @@ func TestTemplateFromLocal(t *testing.T) {
 		Name: "chart-for-template-tests",
 		Dir:  t.TempDir(),
 	})
+	hookManifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: template-hook
+  annotations:
+    "helm.sh/hook": pre-install
+data:
+  marker: hook-manifest
+`
+	if err := os.WriteFile(filepath.Join(create, "templates", "hook.yaml"), []byte(hookManifest), 0600); err != nil {
+		t.Fatalf("Expected hook template creation to succeed, got %s", err)
+	}
 	t.Run("with defaults", func(t *testing.T) {
 		manifests, err := Template(&TemplateOptions{
 			Chart: create,
@@ -38,6 +51,39 @@ func TestTemplateFromLocal(t *testing.T) {
 		}
 		if !strings.Contains(manifests, "name: release-name-chart-for-template-tests") {
 			t.Errorf("Expected template to include provided name, got %s", manifests)
+			return
+		}
+		if strings.Contains(manifests, "marker: hook-manifest") {
+			t.Errorf("Expected template to exclude hooks by default, got %s", manifests)
+			return
+		}
+	})
+	t.Run("with hooks", func(t *testing.T) {
+		manifests, err := Template(&TemplateOptions{
+			Chart:        create,
+			IncludeHooks: true,
+		})
+		if err != nil {
+			t.Errorf("Expected template to succeed, got %s", err)
+			return
+		}
+		if !strings.Contains(manifests, "name: release-name-chart-for-template-tests") {
+			t.Errorf("Expected template to retain ordinary manifests, got %s", manifests)
+			return
+		}
+		if !strings.Contains(manifests, "# Source: chart-for-template-tests/templates/deployment.yaml\n") {
+			t.Errorf("Expected template to preserve ordinary manifest source headers, got %s", manifests)
+			return
+		}
+		if !strings.Contains(
+			manifests,
+			"---\n# Source: chart-for-template-tests/templates/hook.yaml\napiVersion: v1\nkind: ConfigMap\n",
+		) {
+			t.Errorf("Expected template to preserve the hook source path, got %s", manifests)
+			return
+		}
+		if !strings.Contains(manifests, "marker: hook-manifest") {
+			t.Errorf("Expected template to include hooks, got %s", manifests)
 			return
 		}
 	})

--- a/native/main.go
+++ b/native/main.go
@@ -193,6 +193,7 @@ struct TemplateOptions {
 	char* keyring;
 	int   debug;
 	char* repositoryConfig;
+	int   includeHooks;
 };
 
 struct TestOptions {
@@ -702,6 +703,7 @@ func Template(options *C.struct_TemplateOptions) C.Result {
 			},
 			Debug:            options.debug == 1,
 			RepositoryConfig: C.GoString(options.repositoryConfig),
+			IncludeHooks:     options.includeHooks == 1,
 		})
 	})
 }


### PR DESCRIPTION
Add the ability to render the helm hooks.
This is needed when you follow the rendered manifest pattern, and use e.g. flux to rollout the generated manifests