### PR TITLE
fix(registry): honor plainHttp on registry login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.25.10
+  GO_VERSION: 1.26.7
 
 jobs:
   build-all:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.25.10
+  GO_VERSION: 1.26.7
 
 jobs:
   release:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 2 * * *' # Every day at 2am
 
 env:
-  GO_VERSION: 1.25.10
+  GO_VERSION: 1.26.7
 
 jobs:
   snapshots:

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmPushTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmPushTest.java
@@ -61,7 +61,8 @@ class HelmPushTest {
   void pushUnauthorizedThrowsException() {
     final PushCommand pushCommand = Helm.push()
       .withChart(packagedChart)
-      .withRemote(URI.create("oci://" + remoteServer));
+      .withRemote(URI.create("oci://" + remoteServer))
+      .plainHttp();
     assertThatIllegalStateException()
       .isThrownBy(pushCommand::call)
       .extracting(IllegalStateException::getMessage)
@@ -74,6 +75,7 @@ class HelmPushTest {
     final PushCommand pushCommand = Helm.push()
       .withChart(packagedChart)
       .withRemote(URI.create("oci://" + remoteServer))
+      .plainHttp()
       .debug();
     assertThatIllegalStateException()
       .isThrownBy(pushCommand::call)
@@ -88,10 +90,11 @@ class HelmPushTest {
 
   @Test
   void pushAuthorized() {
-    Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).call();
+    Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).plainHttp().call();
     final String result = Helm.push()
       .withChart(packagedChart)
       .withRemote(URI.create("oci://" + remoteServer))
+      .plainHttp()
       .call();
     assertThat(result)
       .contains("Pushed: ", "test:0.1.0", "Digest: ");
@@ -99,10 +102,11 @@ class HelmPushTest {
 
   @Test
   void pushWithDebugShowsDebugMessages() {
-    Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).call();
+    Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).plainHttp().call();
     final String result = Helm.push()
       .withChart(packagedChart)
       .withRemote(URI.create("oci://" + remoteServer))
+      .plainHttp()
       .debug()
       .call();
     assertThat(result)

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmRegistryTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmRegistryTest.java
@@ -43,7 +43,7 @@ class HelmRegistryTest {
     @Test
     void withValidCredentialsSucceeds() {
       final String result = Helm.registry().login()
-        .withHost(remoteServer).withUsername("username").withPassword("password").call();
+        .withHost(remoteServer).withUsername("username").withPassword("password").plainHttp().call();
       assertThat(result).startsWith("Login Succeeded");
     }
 
@@ -51,7 +51,7 @@ class HelmRegistryTest {
     void withDebugAndValidCredentialsSucceeds() {
       final String result = Helm.registry().login()
         .debug()
-        .withHost(remoteServer).withUsername("username").withPassword("password").call();
+        .withHost(remoteServer).withUsername("username").withPassword("password").plainHttp().call();
       assertThat(result)
         .containsPattern(Pattern.compile("^Login Succeeded$", Pattern.MULTILINE))
         .contains("level=info msg=\"authorized request\"");
@@ -60,7 +60,7 @@ class HelmRegistryTest {
     @Test
     void withInvalidCredentialsFails() {
       final RegistryCommand.LoginCommand loginCommand = Helm.registry().login()
-        .withHost(remoteServer).withUsername("username").withPassword("invalid");
+        .withHost(remoteServer).withUsername("username").withPassword("invalid").plainHttp();
       assertThatThrownBy(loginCommand::call)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContainingAll(
@@ -72,7 +72,7 @@ class HelmRegistryTest {
     void withDebugAndInvalidCredentialsFails() {
       final RegistryCommand.LoginCommand loginCommand = Helm.registry().login()
         .debug()
-        .withHost(remoteServer).withUsername("username").withPassword("invalid");
+        .withHost(remoteServer).withUsername("username").withPassword("invalid").plainHttp();
       assertThatThrownBy(loginCommand::call)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContainingAll(
@@ -87,7 +87,7 @@ class HelmRegistryTest {
 
     @Test
     void withPreviousLoginSucceeds() {
-      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword("password").call();
+      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword("password").plainHttp().call();
       final String result = Helm.registry().logout()
         .withHost(remoteServer).call();
       assertThat(result).startsWith("Removing login credentials for " + remoteServer);
@@ -95,7 +95,7 @@ class HelmRegistryTest {
 
     @Test
     void withDebugAndPreviousLoginSucceeds() {
-      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword("password").call();
+      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword("password").plainHttp().call();
       final String result = Helm.registry().logout()
         .debug()
         .withHost(remoteServer).call();

--- a/helm-java/src/test/java/com/marcnuri/helm/HelmShowTest.java
+++ b/helm-java/src/test/java/com/marcnuri/helm/HelmShowTest.java
@@ -137,12 +137,13 @@ class HelmShowTest {
       final String password = UUID.randomUUID().toString(); // If default password is used, test is flaky ¯\_(ツ)_/¯
       remoteServer = Helm.HelmLibHolder.INSTANCE.RepoOciServerStart(
         new RepoServerOptions(null, null, password)).out;
-      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).call();
+      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).plainHttp().call();
       helm.packageIt().withDestination(tempDir).call();
       final Path packagedChart = tempDir.resolve("test-0.1.0.tgz");
       Helm.push()
         .withChart(packagedChart)
         .withRemote(URI.create("oci://" + remoteServer))
+        .plainHttp()
         .call();
     }
 
@@ -172,12 +173,13 @@ class HelmShowTest {
       final String password = UUID.randomUUID().toString(); // If default password is used, test is flaky ¯\_(ツ)_/¯
       remoteServer = Helm.HelmLibHolder.INSTANCE.RepoOciServerStart(
         new RepoServerOptions(null, null, password)).out;
-      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).call();
+      Helm.registry().login().withHost(remoteServer).withUsername("username").withPassword(password).plainHttp().call();
       helm.packageIt().withDestination(tempDir).call();
       final Path packagedChart = tempDir.resolve("test-0.1.0.tgz");
       Helm.push()
         .withChart(packagedChart)
         .withRemote(URI.create("oci://" + remoteServer))
+        .plainHttp()
         .call();
     }
 

--- a/native/internal/helm/registry.go
+++ b/native/internal/helm/registry.go
@@ -60,6 +60,7 @@ func RegistryLogin(options *RegistryOptions) (string, error) {
 		action.WithKeyFile(options.KeyFile),
 		action.WithCAFile(options.CaFile),
 		action.WithInsecure(options.InsecureSkipTLSverify),
+		action.WithPlainHTTPLogin(options.PlainHttp),
 	)
 	return appendToOutOrErr(debugBuffer, getRegistryClientOut().String(), err)
 }

--- a/native/main_test.go
+++ b/native/main_test.go
@@ -166,15 +166,17 @@ func TestPush(t *testing.T) {
 	})
 	_ = helm.Package(&helm.PackageOptions{Path: create, Destination: dir})
 	_, _ = helm.RegistryLogin(&helm.RegistryOptions{
-		Hostname: srv.RegistryURL,
-		Username: "username",
-		Password: "password",
-		Debug:    true,
+		Hostname:    srv.RegistryURL,
+		Username:    "username",
+		Password:    "password",
+		Debug:       true,
+		CertOptions: helm.CertOptions{PlainHttp: true},
 	})
 	out, err := helm.Push(&helm.PushOptions{
-		Chart:  path.Join(dir, "test-0.1.0.tgz"),
-		Remote: "oci://" + srv.RegistryURL,
-		Debug:  true,
+		Chart:       path.Join(dir, "test-0.1.0.tgz"),
+		Remote:      "oci://" + srv.RegistryURL,
+		Debug:       true,
+		CertOptions: helm.CertOptions{PlainHttp: true},
 	})
 	if err != nil {
 		t.Errorf("Expected push to succeed, got %s", err)
@@ -217,9 +219,10 @@ func TestRegistryLogin(t *testing.T) {
 		t.Errorf("Expected server to be started")
 	}
 	_, err = helm.RegistryLogin(&helm.RegistryOptions{
-		Hostname: srv.RegistryURL,
-		Username: "username",
-		Password: "password",
+		Hostname:    srv.RegistryURL,
+		Username:    "username",
+		Password:    "password",
+		CertOptions: helm.CertOptions{PlainHttp: true},
 	})
 	if err != nil {
 		t.Errorf("Expected login to succeed, got %s", err)
@@ -246,16 +249,18 @@ func TestRegistryLogout(t *testing.T) {
 	defer helm.RepoServerStopAll()
 	srv, _ := helm.RepoOciServerStart(&helm.RepoServerOptions{})
 	_, err := helm.RegistryLogin(&helm.RegistryOptions{
-		Hostname: srv.RegistryURL,
-		Username: "username",
-		Password: "password",
+		Hostname:    srv.RegistryURL,
+		Username:    "username",
+		Password:    "password",
+		CertOptions: helm.CertOptions{PlainHttp: true},
 	})
 	if err != nil {
 		t.Error("Expected initial login to succeed")
 	}
 	var out string
 	out, err = helm.RegistryLogout(&helm.RegistryOptions{
-		Hostname: srv.RegistryURL,
+		Hostname:    srv.RegistryURL,
+		CertOptions: helm.CertOptions{PlainHttp: true},
 	})
 	if err != nil {
 		t.Errorf("Expected logout to succeed, got %s", err)


### PR DESCRIPTION
## Problem

`RegistryLogin` builds its registry client with plain-HTTP support, but never passes
`action.WithPlainHTTPLogin(...)` to the login action itself — so `.plainHttp()` was
silently ignored on login.

This went unnoticed because oras-go used to fall back from HTTPS to HTTP and still send
credentials. oras-go **v2.6.1** (a security release) closed that hole: credentials are no
longer forwarded across an HTTPS→HTTP downgrade (GHSA-28r5-37g7-p6mp,
GHSA-xf85-363p-868w). Once that landed, login against a plain-HTTP registry started
failing with `401 unauthorized: authentication required`.

## Changes

- **Fix**: pass `action.WithPlainHTTPLogin(options.PlainHttp)` in `native/internal/helm/registry.go`.
- **Tests**: the Go and Java OCI tests relied on the old insecure fallback; they now
  declare `plainHttp` explicitly against the plain-HTTP test registry.
- **CI**: bump `GO_VERSION` 1.25.10 → 1.26.7. Go 1.25 is out of support, and
  `helm.sh/helm/v3` 3.21.4 requires `go >= 1.26.0`.

## Why now

Two dependabot PRs are red because of this:

- #419 — `helm.sh/helm/v3` 3.21.0 → 3.21.4 (pulls oras-go 2.6.1, and requires Go 1.26)
- #420 — `oras.land/oras-go/v2` 2.6.0 → 2.6.2

Both should go green once this lands and they are rebased.

## Verification

- Full Go suite green.
- 20 Java OCI tests (`HelmPushTest`, `HelmRegistryTest`, `HelmShowTest`) green.
- Both re-verified against oras-go 2.6.2 to confirm the dependabot bumps pass.