### PR TITLE
fix(build): derive xgo image tag from GO_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@
 .DEFAULT_GOAL := help
 
 CGO_ENABLED = 1
+# Go toolchain version. CI exports GO_VERSION (see .github/workflows/*.yml), which
+# overrides this default, so the two cannot drift apart.
+# The xgo image must ship a Go >= the `go` directive in native/go.mod. Otherwise the
+# container silently downloads a newer toolchain whose linker is incompatible with
+# that image's mingw-w64 binutils, and the Windows DLL fails to link.
+GO_VERSION ?= 1.26.7
+XGO_IMAGE = ghcr.io/techknowlogick/xgo:go-$(GO_VERSION)
 LD_FLAGS = -s -w
 COMMON_BUILD_ARGS = -ldflags "$(LD_FLAGS)" -buildmode=c-shared
 MAVEN_OPTIONS =
@@ -59,7 +66,7 @@ build-native: ## Build the native shared library for the current platform
 .PHONY: build-native-cross-platform
 build-native-cross-platform: ## Build native shared libraries for all 5 supported platforms (requires Docker)
 	go install src.techknowlogick.com/xgo@latest
-	xgo -image ghcr.io/techknowlogick/xgo:go-1.25.10 $(COMMON_BUILD_ARGS) -out native/out/helm --targets */arm64,*/amd64 ./native
+	xgo -image $(XGO_IMAGE) $(COMMON_BUILD_ARGS) -out native/out/helm --targets */arm64,*/amd64 ./native
 
 .PHONY: build-java
 build-java: ## Build and verify the Java artifacts (mvn clean verify)


### PR DESCRIPTION
## Problem

The Linux job on #419 fails while cross-compiling the Windows DLL:

```
x86_64-w64-mingw32-ld: /tmp/go-link-*/export_file.def:1: syntax error
x86_64-w64-mingw32-ld: /tmp/go-link-*/export_file.def: file format not
  recognized; treating as linker script
collect2: error: ld returned 1 exit status
```

`helm-windows-4.0-amd64.dll` is therefore never produced, and the build later
stops on:

```
Rule 1: RequireFilesExist failed with message:
  .../native/out/helm-windows-4.0-amd64.dll
```

The enforcer error is the symptom that gets reported, not the cause.

## Root cause

The Go version is pinned in **three** places, and only two were updated when
`GO_VERSION` moved to 1.26.7:

| Pin | Value |
|---|---|
| `native/go.mod` | `go 1.26.0` (raised by #419) |
| `GO_VERSION` in `.github/workflows/*.yml` | `1.26.7` |
| xgo image tag in `Makefile` | **`go-1.25.10`** |

Once `go.mod` requires `>= 1.26.0`, the Go toolchain inside the `go-1.25.10`
container auto-downloads Go 1.26.0 and links with it — against the mingw-w64
binutils that image ships. That older GNU `ld` cannot parse the `.def` file Go
1.26 emits.

This is why `main` stayed green: its `go.mod` still says `1.25.10`, so the
container never downloads a different toolchain and the mismatch never appears.

## Fix

Derive the image tag from `GO_VERSION`. The workflows already export it, and
make's `?=` prefers an environment value over the default, so CI and the
Makefile can no longer drift apart. Local builds default to 1.26.7.

## Verification

Ran the exact failing scenario inside `ghcr.io/techknowlogick/xgo:go-1.26.7`:

- ships `go1.26.7` and **LLD 21.1.8** as `x86_64-w64-mingw32-ld` (not GNU `ld`)
- no toolchain download occurs, since 1.26.7 already satisfies the directive
- a `-buildmode=c-shared` `windows/amd64` build links successfully

Confirmed with `go.mod` at both `go 1.26.0` (as on #419) and `go 1.25.10` (as on
main today), so this is safe to land ahead of #419.

Unblocks #419, the last remaining dependabot PR.